### PR TITLE
add support for plain text in payload (i.e. no JSON)

### DIFF
--- a/plugins/event_source/mqtt.py
+++ b/plugins/event_source/mqtt.py
@@ -71,7 +71,10 @@ async def main(queue: asyncio.Queue, args: Dict[str, Any]) -> None:
             await mqtt_consumer.subscribe(topic)
             async for message in messages:
                 try:
-                    data = json.loads(message.payload.decode())
+                    try:
+                        data = json.loads(message.payload.decode())
+                    except json.decoder.JSONDecodeError:
+                        data = dict(payload=message.payload.decode())
                     await queue.put(data)
                 except json.decoder.JSONDecodeError:
                     logger.exception("Decoding exception for incoming message")


### PR DESCRIPTION
this permits something like `condition: event.payload == 'hello'` for an MQTT publish with  a payload consisting of the word "hello"

```console
mosquitto_pub -t anomaly-data-out -m hello
```