### PR TITLE
Change decision environment module name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ A sample playbook to create items using the modules is shown below:
             decision_env: Decision Environment 2
 
     - name: Create EDA Decision Environments
-      kubealex.eda.eda_decision_envs:
+      kubealex.eda.eda_decision_environment:
         controller_url: "https://example-controller.com"
         controller_user: "admin"
         controller_password: "admin123"


### PR DESCRIPTION
I was looking at the galaxy documentation for the collection, copied the playbook example and was encountering this issue, "couldn't resolve module/action 'kubealex.eda.eda_decision_envs'".